### PR TITLE
Change byte array handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ When transpiling class, struct, and record, only `public` fields and properties 
 | Guid |  string  | Compatible with TypeScript's `crypto.randomUUID()`. | 
 | DateTime | (Date \| string) or Date | Json: `(Date \| string)`,  MessagePack: `Date`. |
 | System.Nullable\<T\>| (T \| undefined) |
+| byte[] | string or Uint8Array | JSON: `string` (base64), MessagePack `Uint8Array`. |
 | T[] | T[] | 
 | System.Array | any[] | ❌ System.Text.Json |
 | ArraySegment\<T\> | T[] | ❌ System.Text.Json |

--- a/src/Tapper/DefaultTypeMapperProvider.cs
+++ b/src/Tapper/DefaultTypeMapperProvider.cs
@@ -15,7 +15,7 @@ public class DefaultTypeMapperProvider : ITypeMapperProvider
 
     public DefaultTypeMapperProvider(Compilation compilation)
     {
-        _arrayTypeMapper = new ArrayTypeMapper();
+        _arrayTypeMapper = new ArrayTypeMapper(compilation);
         _tupleTypeMapper = new TupleTypeMapper();
 
         var dateTimeTypeMapper = new DateTimeTypeMapper(compilation);

--- a/tests/Tapper.Tests.Server/Controllers/TapperController.cs
+++ b/tests/Tapper.Tests.Server/Controllers/TapperController.cs
@@ -78,11 +78,25 @@ public class TapperController : ControllerBase
     }
 
     [HttpPost]
-    public Type5? Test5(Type5 type4)
+    public Type5? Test5(Type5 type5)
     {
-        if (type4.Value == 'R')
+        if (type5.Value == 'R')
         {
             return new Type5('S');
+        }
+
+        return null;
+    }
+
+    [HttpPost]
+    public Type6? Test6(Type6 type6)
+    {
+        if (type6.Binary.Length == 3
+            && type6.Binary[0] == 0
+            && type6.Binary[1] == 7
+            && type6.Binary[2] == 99)
+        {
+            return new Type6(new byte[] { 99, 7, 0 });
         }
 
         return null;

--- a/tests/Tapper.Tests.Server/Models/Models.cs
+++ b/tests/Tapper.Tests.Server/Models/Models.cs
@@ -62,3 +62,7 @@ public record Type4(MyEnum MyEnum, float Value);
 
 [TranspilationSource]
 public record Type5(char Value);
+
+
+[TranspilationSource]
+public record Type6(byte[] Binary);

--- a/tests/TypeScriptTest/src/fetch.json.test.ts
+++ b/tests/TypeScriptTest/src/fetch.json.test.ts
@@ -1,5 +1,5 @@
-import { fetchType2, fetchType3, fetchType4, fetchType5 } from './fetch.json'
-import { MyEnum, Type2, Type3, Type4, Type5 } from './generated/json/Tapper.Tests.Server.Models'
+import { fetchType2, fetchType3, fetchType4, fetchType5, fetchType6 } from './fetch.json'
+import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/json/Tapper.Tests.Server.Models'
 
 test('fetch1.json', async () => {
     const res = await fetchType2();
@@ -42,3 +42,16 @@ test('fetch5.json', async () => {
     }
     expect(res).toEqual(gt);
 });
+
+test('fetch6.json', async () => {
+    const res = await fetchType6();
+
+    const gt: Type6 =
+    {
+        Binary: Buffer.from([99, 7, 0]).toString("base64")
+    }
+
+    expect(res).toEqual(gt);
+});
+
+

--- a/tests/TypeScriptTest/src/fetch.json.ts
+++ b/tests/TypeScriptTest/src/fetch.json.ts
@@ -1,4 +1,4 @@
-import { MyEnum, Type2, Type3, Type4, Type5 } from './generated/json/Tapper.Tests.Server.Models';
+import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/json/Tapper.Tests.Server.Models';
 import { randomUUID } from 'crypto';
 import fetch from 'node-fetch';
 
@@ -67,3 +67,40 @@ export const fetchType5 = async () => {
     return await response.json() as Type5;
 }
 
+export const fetchType6 = async () => {
+    const obj: Type6 = {
+        Binary: Buffer.from([0, 7, 99]).toString("base64")
+    }
+
+    const response = await fetch("http://localhost:5100/tapper/test6", {
+        method: "POST",
+        body: JSON.stringify(obj),
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+    const ret = await response.json() as Type6;
+
+    return ret;
+}
+
+// Base64 => Uint8Array
+class Base64Encoder extends TextEncoder{
+    constructor(){
+        super();
+    }
+
+    encode(text : string){
+        return super.encode(atob(text));
+    }
+}
+
+// Uint8Array => Base64
+class Base64Decoder extends TextDecoder{
+    constructor(){
+        super();
+    }
+
+    decode(buffer : Uint8Array){
+        return btoa(super.decode(buffer));
+    }
+}

--- a/tests/TypeScriptTest/src/fetch.msgpack.test.ts
+++ b/tests/TypeScriptTest/src/fetch.msgpack.test.ts
@@ -1,5 +1,5 @@
-import { fetchType2, fetchType3, fetchType4, fetchType5 } from './fetch.msgpack'
-import { MyEnum, Type2, Type3, Type4, Type5 } from './generated/msgpack/Tapper.Tests.Server.Models'
+import { fetchType2, fetchType3, fetchType4, fetchType5, fetchType6 } from './fetch.msgpack'
+import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/msgpack/Tapper.Tests.Server.Models'
 
 test('fetch1.msgpack', async () => {
     const res = await fetchType2();
@@ -39,5 +39,20 @@ test('fetch5.msgpack', async () => {
     {
         Value: 83
     }
+    expect(res).toEqual(gt);
+});
+
+test('fetch6.msgpack', async () => {
+    const res = await fetchType6();
+
+    if (res.Binary instanceof Uint8Array) {
+        res.Binary = new Uint8Array(res.Binary)
+    }
+
+    const gt: Type6 =
+    {
+        Binary: new Uint8Array([99, 7, 0])
+    }
+
     expect(res).toEqual(gt);
 });

--- a/tests/TypeScriptTest/src/fetch.msgpack.ts
+++ b/tests/TypeScriptTest/src/fetch.msgpack.ts
@@ -1,4 +1,4 @@
-import { MyEnum, Type2, Type3, Type4, Type5 } from './generated/msgpack/Tapper.Tests.Server.Models';
+import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/msgpack/Tapper.Tests.Server.Models';
 import { randomUUID } from 'crypto';
 import { encode, decode } from "@msgpack/msgpack";
 import fetch from 'node-fetch';
@@ -84,7 +84,27 @@ export const fetchType5 = async () => {
     });
 
     const buf = await response.buffer()
-    const ret = decode<Type4>(buf);
+    const ret = decode<Type5>(buf);
+
+    return ret;
+}
+
+export const fetchType6 = async () => {
+    const obj: Type6 = {
+        Binary: new Uint8Array([0, 7, 99])
+    }
+
+    const response = await fetch("http://localhost:5100/tapper/test6", {
+        method: "POST",
+        body: encode(obj),
+        headers: {
+            'Content-Type': 'application/x-msgpack',
+            'Accept': 'application/x-msgpack'
+        },
+    });
+
+    const buf = await response.buffer()
+    const ret = decode<Type6>(buf) as Type6;
 
     return ret;
 }


### PR DESCRIPTION
Changed the TypeScript type corresponding to C # byte array.

## Before
```
byte[] -> number[]
```

## After

```
byte[] -> string : JSON
byte[] -> Uint8Array : MessagePack
```

## Differences in binary handling between serializers.

### JSON

System.Text.Json serializes byte[] to base64 string and deserialize base64 string to byte[].
By default, JSON number array cannot be deserialized to byte [].

![image](https://user-images.githubusercontent.com/27144255/164889840-f7693a25-dbfd-4953-8f64-87a9d354f7d3.png)

JSON.stringify does not serialize Uint8Array to base64.

```
> JSON.stringify(new Uint8Array([0,7,99]))
'{"0":0,"1":7,"2":99}'
```

To convert Uint8Array to base64 string, for example, write the following code.

```
const src = new Uint8Array(7);

const b64 : string = Buffer.from(src).toString("base64")
const buf : Buffer = Buffer.from(b64, "base64")

const u8a = new Uint8Array(buf)
```

### MessagePack

[MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp) serializes `byte[]` as [bin format family](https://github.com/msgpack/msgpack/blob/master/spec.md#bin-format-family) and deserialize [bin format family](https://github.com/msgpack/msgpack/blob/master/spec.md#bin-format-family) to `byte[]`.

[msgpack-javascript](https://github.com/msgpack/msgpack-javascript) serializes `ArrayBufferView` as [bin format family](https://github.com/msgpack/msgpack/blob/master/spec.md#bin-format-family) and deserialize [bin format family](https://github.com/msgpack/msgpack/blob/master/spec.md#bin-format-family) to `Uint8Array`.