### PR TITLE
Add enum naming style

### DIFF
--- a/src/Tapper/ITranspilationOptions.cs
+++ b/src/Tapper/ITranspilationOptions.cs
@@ -5,6 +5,7 @@ public interface ITranspilationOptions
     ITypeMapperProvider TypeMapperProvider { get; }
     SerializerOption SerializerOption { get; }
     NamingStyle NamingStyle { get; }
+    EnumNamingStyle EnumNamingStyle { get; }
 }
 
 public enum SerializerOption
@@ -15,6 +16,13 @@ public enum SerializerOption
 }
 
 public enum NamingStyle
+{
+    None,
+    CamelCase,
+    PascalCase
+}
+
+public enum EnumNamingStyle
 {
     None,
     CamelCase,

--- a/src/Tapper/TranspilationOptions.cs
+++ b/src/Tapper/TranspilationOptions.cs
@@ -8,13 +8,17 @@ public class TranspilationOptions : ITranspilationOptions
 
     public NamingStyle NamingStyle { get; }
 
+    public EnumNamingStyle EnumNamingStyle { get; }
+
     public TranspilationOptions(
         ITypeMapperProvider typeMapperProvider,
         SerializerOption serializerOption,
-        NamingStyle namingStyle)
+        NamingStyle namingStyle,
+        EnumNamingStyle enumNamingStyle)
     {
         TypeMapperProvider = typeMapperProvider;
         SerializerOption = serializerOption;
         NamingStyle = namingStyle;
+        EnumNamingStyle = enumNamingStyle;
     }
 }

--- a/src/Tapper/Transpiler.cs
+++ b/src/Tapper/Transpiler.cs
@@ -13,12 +13,12 @@ public class Transpiler
     private readonly ILogger _logger;
     private readonly ICodeGenerator _codeGenerator;
 
-    public Transpiler(Compilation compilation, string newLine, int indent, SerializerOption serializerOption, NamingStyle namingStyle, ILogger logger)
+    public Transpiler(Compilation compilation, string newLine, int indent, SerializerOption serializerOption, NamingStyle namingStyle, EnumNamingStyle enumNamingStyle, ILogger logger)
     {
         _newLine = newLine;
         _logger = logger;
 
-        _codeGenerator = new TypeScriptCodeGenerator(compilation, newLine, indent, serializerOption, namingStyle, logger);
+        _codeGenerator = new TypeScriptCodeGenerator(compilation, newLine, indent, serializerOption, namingStyle, enumNamingStyle, logger);
 
         _targetTypes = compilation.GetSourceTypes();
         _targetTypeLookupTable = _targetTypes.ToLookup<INamedTypeSymbol, INamespaceSymbol>(static x => x.ContainingNamespace, SymbolEqualityComparer.Default);

--- a/src/Tapper/TypeScriptCodeGenerator.cs
+++ b/src/Tapper/TypeScriptCodeGenerator.cs
@@ -14,9 +14,16 @@ public class TypeScriptCodeGenerator : ICodeGenerator
     private readonly INamedTypeSymbol _nullableStructTypeSymbol;
     private readonly ITranspilationOptions _transpilationOptions;
 
-    public TypeScriptCodeGenerator(Compilation compilation, string newLine, int indent, SerializerOption serializerOption, NamingStyle namingStyle, ILogger _)
+    public TypeScriptCodeGenerator(
+        Compilation compilation,
+        string newLine,
+        int indent,
+        SerializerOption serializerOption,
+        NamingStyle namingStyle,
+        EnumNamingStyle enumNamingStyle,
+        ILogger _)
     {
-        _transpilationOptions = new TranspilationOptions(new DefaultTypeMapperProvider(compilation), serializerOption, namingStyle);
+        _transpilationOptions = new TranspilationOptions(new DefaultTypeMapperProvider(compilation), serializerOption, namingStyle, enumNamingStyle);
 
         _sourceTypes = compilation.GetSourceTypes();
         _nullableStructTypeSymbol = compilation.GetTypeByMetadataName("System.Nullable`1")!;
@@ -68,7 +75,7 @@ public class TypeScriptCodeGenerator : ICodeGenerator
 
         foreach (var member in members.OfType<IFieldSymbol>())
         {
-            writer.Append($"{_indent}{Transform(member.Name, _transpilationOptions.NamingStyle)} = {member.ConstantValue},{_newLine}");
+            writer.Append($"{_indent}{Transform(member.Name, _transpilationOptions.EnumNamingStyle)} = {member.ConstantValue},{_newLine}");
         }
 
         writer.Append('}');
@@ -164,6 +171,16 @@ public class TypeScriptCodeGenerator : ICodeGenerator
         {
             NamingStyle.PascalCase => $"{char.ToUpper(text[0])}{text[1..]}",
             NamingStyle.CamelCase => $"{char.ToLower(text[0])}{text[1..]}",
+            _ => text,
+        };
+    }
+
+    private static string Transform(string text, EnumNamingStyle enumNamingStyle)
+    {
+        return enumNamingStyle switch
+        {
+            EnumNamingStyle.PascalCase => $"{char.ToUpper(text[0])}{text[1..]}",
+            EnumNamingStyle.CamelCase => $"{char.ToLower(text[0])}{text[1..]}",
             _ => text,
         };
     }

--- a/tests/Tapper.Tests/CollectionClassesTest.cs
+++ b/tests/Tapper.Tests/CollectionClassesTest.cs
@@ -27,7 +27,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldArray);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -50,7 +50,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldArraySegmentint);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -73,7 +73,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldListfloat);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -96,7 +96,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldLinkedListstring);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -119,7 +119,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldQueueGuid);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -142,7 +142,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldStackUri);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -165,7 +165,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldHashSetDateTime);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -188,7 +188,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldIEnumerablebool);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -211,7 +211,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldIReadOnlyCollectionbyte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -234,7 +234,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldIReadOnlyListobject);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -257,7 +257,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldICollectionstring);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -280,7 +280,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldIListbool);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -303,7 +303,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionFieldISetsbyte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -327,7 +327,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyArray);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -350,7 +350,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyArraySegmentint);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -373,7 +373,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyListfloat);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -396,7 +396,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyLinkedListstring);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -419,7 +419,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyQueueGuid);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -442,7 +442,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyStackUri);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -465,7 +465,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyHashSetDateTime);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -488,7 +488,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyIEnumerablebool);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -511,7 +511,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyIReadOnlyCollectionbyte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -534,7 +534,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyIReadOnlyListobject);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -557,7 +557,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyICollectionstring);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -580,7 +580,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyIListbool);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -603,7 +603,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionPropertyISetsbyte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/CollectionClassesTest.tt
+++ b/tests/Tapper.Tests/CollectionClassesTest.tt
@@ -58,7 +58,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionField<#= Format(type.Key) #>);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -84,7 +84,7 @@ public class CollectionMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeCollectionProperty<#= Format(type.Key) #>);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/DictionaryClassesTest.cs
+++ b/tests/Tapper.Tests/DictionaryClassesTest.cs
@@ -27,7 +27,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryFieldDictionaryintstring);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -50,7 +50,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryFieldIDictionaryfloatGuid);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -73,7 +73,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryFieldIReadOnlyDictionarystringDateTime);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -97,7 +97,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryPropertyDictionaryintstring);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -120,7 +120,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryPropertyIDictionaryfloatGuid);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -143,7 +143,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryPropertyIReadOnlyDictionarystringDateTime);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/DictionaryClassesTest.tt
+++ b/tests/Tapper.Tests/DictionaryClassesTest.tt
@@ -48,7 +48,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryField<#= Format(type.Key) #>);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -74,7 +74,7 @@ public class DictionaryMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludeDictionaryProperty<#= Format(type.Key) #>);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/EnumTest.cs
+++ b/tests/Tapper.Tests/EnumTest.cs
@@ -23,7 +23,7 @@ public class EnumTest
     public void Test_Enum1()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(Enum1);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -50,7 +50,7 @@ export enum Enum1 {
     public void Test_Enum2()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(Enum2);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/HeaderTest.cs
+++ b/tests/Tapper.Tests/HeaderTest.cs
@@ -20,7 +20,7 @@ public class HeaderTest
     public void Test_Header()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var targetTypes = compilation.GetSourceTypes();
         var targetTypeLookupTable = targetTypes.ToLookup<INamedTypeSymbol, INamespaceSymbol>(static x => x.ContainingNamespace, SymbolEqualityComparer.Default);

--- a/tests/Tapper.Tests/NestedNamespaceTest.cs
+++ b/tests/Tapper.Tests/NestedNamespaceTest.cs
@@ -23,7 +23,7 @@ public class NestedNamespaceTest
     public void Test1()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(NastingNamespaceType);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/PrimitiveClassesTest.cs
+++ b/tests/Tapper.Tests/PrimitiveClassesTest.cs
@@ -27,7 +27,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemBoolean);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -50,7 +50,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemByte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -73,7 +73,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemSByte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -96,7 +96,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemChar);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -119,7 +119,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemDecimal);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -142,7 +142,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemDouble);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -165,7 +165,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemSingle);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -188,7 +188,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemInt32);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -211,7 +211,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemUInt32);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -234,7 +234,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemInt64);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -257,7 +257,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemUInt64);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -280,7 +280,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemInt16);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -303,7 +303,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemUInt16);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -326,7 +326,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemObject);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -349,7 +349,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemString);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -372,7 +372,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemUri);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -395,7 +395,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemGuid);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -418,7 +418,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveFieldSystemDateTime);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -443,7 +443,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemBoolean);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -466,7 +466,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemByte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -489,7 +489,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemSByte);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -512,7 +512,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemChar);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -535,7 +535,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemDecimal);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -558,7 +558,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemDouble);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -581,7 +581,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemSingle);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -604,7 +604,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemInt32);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -627,7 +627,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemUInt32);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -650,7 +650,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemInt64);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -673,7 +673,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemUInt64);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -696,7 +696,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemInt16);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -719,7 +719,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemUInt16);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -742,7 +742,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemObject);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -765,7 +765,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemString);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -788,7 +788,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemUri);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -811,7 +811,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemGuid);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -834,7 +834,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitivePropertySystemDateTime);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/PrimitiveClassesTest.tt
+++ b/tests/Tapper.Tests/PrimitiveClassesTest.tt
@@ -80,7 +80,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveField<#= type.Key.FullName.Replace(".", null) #>);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -107,7 +107,7 @@ public class PrimitiveMapTest
     {
         var compilation = CompilationSingleton.Compilation;
 
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(ClassIncludePrimitiveProperty<#= type.Key.FullName.Replace(".", null) #>);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;

--- a/tests/Tapper.Tests/TupleTest.cs
+++ b/tests/Tapper.Tests/TupleTest.cs
@@ -18,7 +18,7 @@ public class TupleTest
     public void Test_SimpleTupleClass()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(SimpleTupleClass);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -45,7 +45,7 @@ export type SimpleTupleClass = {
     public void Test_TupleClassIncludeNullable()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(TupleClassIncludeNullable);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -72,7 +72,7 @@ export type TupleClassIncludeNullable = {
     public void Test_TupleClassNullableField()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(TupleClassNullableField);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
@@ -98,7 +98,7 @@ export type TupleClassNullableField = {
     public void Test_TupleClassIncludeCustomType()
     {
         var compilation = CompilationSingleton.Compilation;
-        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, Logger.Empty);
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, Environment.NewLine, 2, SerializerOption.Json, NamingStyle.None, EnumNamingStyle.None, Logger.Empty);
 
         var type = typeof(TupleClassIncludeCustomType);
         var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;


### PR DESCRIPTION
TypeScript generally uses camelCase for naming conventions for most members, but enum use PascalCase.
Until now, when transpiling from C# to TypeScript, enum, class, struct, and record were converted using a unified naming convention. However, with this PR, the naming convention can now be controlled separately.