### PR TITLE
Transpilation of types in referenced assemblies

### DIFF
--- a/Tapper.sln
+++ b/Tapper.sln
@@ -29,7 +29,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tapper.Tests", "tests\Tappe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tapper.Tests.Analyzer", "tests\Tapper.Tests.Analyzer\Tapper.Tests.Analyzer.csproj", "{A5FE864E-1243-4504-990C-ED5DBE9B8762}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tapper.Tests.Server", "tests\Tapper.Tests.Server\Tapper.Tests.Server.csproj", "{A6E38AD0-2AFB-48A8-8EF9-FB4F31F33072}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tapper.Tests.Server", "tests\Tapper.Tests.Server\Tapper.Tests.Server.csproj", "{A6E38AD0-2AFB-48A8-8EF9-FB4F31F33072}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tapper.Test.SourceTypes.References", "tests\Tapper.Test.SourceTypes.References\Tapper.Test.SourceTypes.References.csproj", "{6219F1C0-D108-484F-89A5-72F6336382BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +83,10 @@ Global
 		{A6E38AD0-2AFB-48A8-8EF9-FB4F31F33072}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6E38AD0-2AFB-48A8-8EF9-FB4F31F33072}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6E38AD0-2AFB-48A8-8EF9-FB4F31F33072}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6219F1C0-D108-484F-89A5-72F6336382BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6219F1C0-D108-484F-89A5-72F6336382BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6219F1C0-D108-484F-89A5-72F6336382BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6219F1C0-D108-484F-89A5-72F6336382BE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,6 +103,7 @@ Global
 		{9EBBE9BE-2498-402A-B53F-704550FF584F} = {DC7F780E-3C20-4CFA-9CA9-1DB36806958F}
 		{A5FE864E-1243-4504-990C-ED5DBE9B8762} = {DC7F780E-3C20-4CFA-9CA9-1DB36806958F}
 		{A6E38AD0-2AFB-48A8-8EF9-FB4F31F33072} = {DC7F780E-3C20-4CFA-9CA9-1DB36806958F}
+		{6219F1C0-D108-484F-89A5-72F6336382BE} = {DC7F780E-3C20-4CFA-9CA9-1DB36806958F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2BBF417F-E9B4-477F-B9AF-D2016323172E}

--- a/src/Tapper.Analyzer/Tapper.Analyzer.csproj
+++ b/src/Tapper.Analyzer/Tapper.Analyzer.csproj
@@ -29,13 +29,14 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>
         <Compile Include="..\Tapper\RoslynExtensions.cs" LinkBase="" />
+        <Compile Include="..\Tapper\ReferencedTypeCollector.cs" LinkBase="" />
     </ItemGroup>
 
 </Project>

--- a/src/Tapper.Generator/Properties/launchSettings.json
+++ b/src/Tapper.Generator/Properties/launchSettings.json
@@ -19,6 +19,10 @@
         "Tapper.Generator4": {
             "commandName": "Project",
             "commandLineArgs": "--project ..\\..\\..\\..\\..\\tests\\Tapper.Tests.Server\\Tapper.Tests.Server.csproj --output ..\\..\\..\\..\\..\\tests\\TypeScriptTest\\src\\generated\\msgpack --serializer messagepack --naming-style none --enum-naming-style none"
+        },
+        "Tapper.Generator5": {
+            "commandName": "Project",
+            "commandLineArgs": "--project ..\\..\\..\\..\\..\\tests\\Tapper.Test.SourceTypes.References\\Tapper.Test.SourceTypes.References.csproj --output ..\\..\\..\\..\\..\\tests\\TypeScriptTest\\src\\generated\\json"
         }
     }
 }

--- a/src/Tapper/DefaultTypeMapperProvider.cs
+++ b/src/Tapper/DefaultTypeMapperProvider.cs
@@ -23,12 +23,13 @@ public class DefaultTypeMapperProvider : ITypeMapperProvider
 
         var primitiveTypeMappers = PrimitiveTypeMappers.Create(compilation);
         var collectionTypeTypeMappers = CollectionTypeTypeMappers.Create(compilation);
-        var dictionalyTypeMappers = DictionalyTypeMappers.Create(compilation);
+        var dictionalyTypeMappers = DictionaryTypeMappers.Create(compilation);
 
         var sourceTypeMapper = compilation.GetSourceTypes()
             .Select(static x => new SourceTypeMapper(x));
 
-        var typeMappers = sourceTypeMapper.Concat(primitiveTypeMappers)
+        var typeMappers = sourceTypeMapper
+            .Concat(primitiveTypeMappers)
             .Concat(collectionTypeTypeMappers)
             .Concat(dictionalyTypeMappers)
             .Concat(new ITypeMapper[] { dateTimeTypeMapper, nullableStructTypeMapper });

--- a/src/Tapper/ReferencedTypeCollector.cs
+++ b/src/Tapper/ReferencedTypeCollector.cs
@@ -28,7 +28,8 @@ internal class ReferencedTypeCollector : SymbolVisitor
         var memberTypes = types
             .SelectMany(static x => x.GetPublicFieldsAndProperties().IgnoreStatic()
                 .SelectMany(RoslynExtensions.GetRelevantTypesFromMemberSymbol))
-            .Where(static x => x.SpecialType == SpecialType.None && !x.IsUnmanagedType)
+            .OfType<INamedTypeSymbol>()
+            .Where(static x => x.SpecialType == SpecialType.None && !x.IsUnmanagedType && !x.IsGenericType)
             .Distinct(SymbolEqualityComparer.Default)
             .OfType<INamedTypeSymbol>()
             .ToArray();

--- a/src/Tapper/ReferencedTypeCollector.cs
+++ b/src/Tapper/ReferencedTypeCollector.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Tapper;
+
+internal class ReferencedTypeCollector : SymbolVisitor
+{
+    private readonly INamedTypeSymbol[] _targetTypes;
+    private readonly HashSet<INamedTypeSymbol> _referencedTypes;
+    public ReferencedTypeCollector(INamedTypeSymbol[] targetTypes)
+    {
+        _referencedTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        _targetTypes = targetTypes;
+    }
+
+    public ImmutableArray<INamedTypeSymbol> GetReferencedTypes() => _referencedTypes.ToImmutableArray();
+
+    private static bool RecursiveReferences(INamedTypeSymbol type, INamedTypeSymbol[] types)
+    {
+        if (types.Length == 0)
+        {
+            return false;
+        }
+
+        var memberTypes = types
+            .SelectMany(static x => x.GetPublicFieldsAndProperties().IgnoreStatic()
+                .SelectMany(RoslynExtensions.GetRelevantTypesFromMemberSymbol))
+            .Where(static x => x.SpecialType == SpecialType.None && !x.IsUnmanagedType)
+            .Distinct(SymbolEqualityComparer.Default)
+            .OfType<INamedTypeSymbol>()
+            .ToArray();
+
+        var isMemberReference = memberTypes.Contains(type, SymbolEqualityComparer.Default);
+
+        var baseTypes = types
+            .Where(static x => x.BaseType is not null && x.BaseType.SpecialType != SpecialType.System_Object && x.BaseType.SpecialType != SpecialType.System_Enum && x.BaseType.SpecialType != SpecialType.System_ValueType)
+            .Select(static x => x.BaseType)
+            .Distinct(SymbolEqualityComparer.Default)
+            .OfType<INamedTypeSymbol>()
+            .ToArray();
+
+        var isBaseTypeReference = baseTypes.Any(x => SymbolEqualityComparer.Default.Equals(x, type));
+
+        return isMemberReference || isBaseTypeReference || RecursiveReferences(type, memberTypes) || RecursiveReferences(type, baseTypes);
+
+    }
+
+    public override void VisitAssembly(IAssemblySymbol symbol)
+    {
+        if (symbol.Name == "System.Runtime")
+        {
+            return;
+        }
+
+        symbol.GlobalNamespace.Accept(this);
+
+    }
+
+    public override void VisitNamespace(INamespaceSymbol symbol)
+    {
+        if (symbol.Name == "System")
+        {
+            return;
+        }
+
+        foreach (var namespaceOrType in symbol.GetMembers())
+        {
+            namespaceOrType.Accept(this);
+        }
+
+    }
+
+    public override void VisitNamedType(INamedTypeSymbol type)
+    {
+        if (type.SpecialType != SpecialType.None ||
+            type.IsUnmanagedType ||
+            !type.IsAccessibleOutsideOfAssembly() ||
+            !RecursiveReferences(type, _targetTypes) ||
+            !_referencedTypes.Add(type))
+            return;
+
+        var nestedTypes = type.GetTypeMembers();
+
+        if (nestedTypes.IsDefaultOrEmpty)
+            return;
+
+        foreach (var nestedType in nestedTypes)
+        {
+            nestedType.Accept(this);
+        }
+    }
+
+
+}
+
+internal static class ISymbolExtensions
+{
+    /// <summary>
+    /// Taken from https://stackoverflow.com/questions/64623689/get-all-types-from-compilation-using-roslyn
+    /// </summary>
+    public static bool IsAccessibleOutsideOfAssembly(this ISymbol symbol) =>
+        symbol.DeclaredAccessibility switch
+        {
+            Accessibility.Private => false,
+            Accessibility.Internal => false,
+            Accessibility.ProtectedAndInternal => false,
+            Accessibility.Protected => true,
+            Accessibility.ProtectedOrInternal => true,
+            Accessibility.Public => true,
+            _ => true,    //Here should be some reasonable default
+        };
+}

--- a/src/Tapper/Tapper.csproj
+++ b/src/Tapper/Tapper.csproj
@@ -33,8 +33,8 @@
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>
         </None>
-        <None Include="TypeMappers\DictionalyTypeMappers.cs">
-            <DependentUpon>DictionalyTypeMappers.tt</DependentUpon>
+        <None Include="TypeMappers\DictionaryTypeMappers.cs">
+            <DependentUpon>DictionaryTypeMappers.tt</DependentUpon>
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>
         </None>
@@ -50,8 +50,8 @@
             <LastGenOutput>CollectionTypeTypeMappers.cs</LastGenOutput>
             <Generator>TextTemplatingFileGenerator</Generator>
         </None>
-        <None Update="TypeMappers\DictionalyTypeMappers.tt">
-            <LastGenOutput>DictionalyTypeMappers.cs</LastGenOutput>
+        <None Update="TypeMappers\DictionaryTypeMappers.tt">
+            <LastGenOutput>DictionaryTypeMappers.cs</LastGenOutput>
             <Generator>TextTemplatingFileGenerator</Generator>
         </None>
         <None Update="TypeMappers\PrimitiveTypeMappers.tt">
@@ -70,6 +70,11 @@
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>
             <DependentUpon>DictionalyTypeMappers.tt</DependentUpon>
+        </Compile>
+        <Compile Update="TypeMappers\DictionaryTypeMappers.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>DictionaryTypeMappers.tt</DependentUpon>
         </Compile>
         <Compile Update="TypeMappers\PrimitiveTypeMappers.cs">
             <DesignTime>True</DesignTime>

--- a/src/Tapper/Transpiler.cs
+++ b/src/Tapper/Transpiler.cs
@@ -21,6 +21,7 @@ public class Transpiler
         _codeGenerator = new TypeScriptCodeGenerator(compilation, newLine, indent, serializerOption, namingStyle, enumNamingStyle, logger);
 
         _targetTypes = compilation.GetSourceTypes();
+
         _targetTypeLookupTable = _targetTypes.ToLookup<INamedTypeSymbol, INamespaceSymbol>(static x => x.ContainingNamespace, SymbolEqualityComparer.Default);
     }
 

--- a/src/Tapper/TypeMappers/DictionaryTypeMappers.cs
+++ b/src/Tapper/TypeMappers/DictionaryTypeMappers.cs
@@ -82,7 +82,7 @@ public class IReadOnlyDictionary2TypeMapper : ITypeMapper
     }
 }
 
-public static class DictionalyTypeMappers
+public static class DictionaryTypeMappers
 {
     public static ITypeMapper[] Create(Compilation compilation)
     {

--- a/src/Tapper/TypeMappers/DictionaryTypeMappers.tt
+++ b/src/Tapper/TypeMappers/DictionaryTypeMappers.tt
@@ -49,7 +49,7 @@ public class <#= type.Name.Replace("`", null) #>TypeMapper : ITypeMapper
 }
 
 <# } #>
-public static class DictionalyTypeMappers
+public static class DictionaryTypeMappers
 {
     public static ITypeMapper[] Create(Compilation compilation)
     {

--- a/src/Tapper/TypeScriptCodeGenerator.cs
+++ b/src/Tapper/TypeScriptCodeGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
@@ -116,7 +117,8 @@ public class TypeScriptCodeGenerator : ICodeGenerator
 
         if (typeSymbol.BaseType is not null &&
             typeSymbol.BaseType.IsType &&
-            typeSymbol.BaseType.SpecialType != SpecialType.System_Object)
+            typeSymbol.BaseType.SpecialType != SpecialType.System_Object &&
+            typeSymbol.BaseType.SpecialType != SpecialType.System_ValueType)
         {
             if (_sourceTypes.Contains(typeSymbol.BaseType, SymbolEqualityComparer.Default))
             {

--- a/tests/Tapper.Test.SourceTypes.References/ReferencesType.cs
+++ b/tests/Tapper.Test.SourceTypes.References/ReferencesType.cs
@@ -1,0 +1,8 @@
+namespace Tapper.Test.SourceTypes.References;
+
+
+[TranspilationSource]
+public class ReferencesType
+{
+    public InheritanceClass0? InheritanceClass0 { get; set; } = null;
+}

--- a/tests/Tapper.Test.SourceTypes.References/Tapper.Test.SourceTypes.References.csproj
+++ b/tests/Tapper.Test.SourceTypes.References/Tapper.Test.SourceTypes.References.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tapper.Test.SourceTypes\Tapper.Test.SourceTypes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Tapper.Tests.Server/Controllers/TapperController.cs
+++ b/tests/Tapper.Tests.Server/Controllers/TapperController.cs
@@ -101,4 +101,21 @@ public class TapperController : ControllerBase
 
         return null;
     }
+
+    [HttpPost]
+    public Type7? Test7(Type7 type7)
+    {
+        if (type7?.ReferencesType?.InheritanceClass0?.Value0 == 1337)
+        {
+            return new Type7(new Test.SourceTypes.References.ReferencesType
+            {
+                InheritanceClass0 = new Test.SourceTypes.InheritanceClass0
+                {
+                    Value0 = 1337
+                }
+            });
+        }
+
+        return null;
+    }
 }

--- a/tests/Tapper.Tests.Server/Models/Models.cs
+++ b/tests/Tapper.Tests.Server/Models/Models.cs
@@ -1,4 +1,5 @@
 using MessagePack;
+using Tapper.Test.SourceTypes.References;
 
 namespace Tapper.Tests.Server.Models;
 
@@ -66,3 +67,6 @@ public record Type5(char Value);
 
 [TranspilationSource]
 public record Type6(byte[] Binary);
+
+[TranspilationSource]
+public record Type7(ReferencesType ReferencesType);

--- a/tests/Tapper.Tests.Server/Tapper.Tests.Server.csproj
+++ b/tests/Tapper.Tests.Server/Tapper.Tests.Server.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Tapper.Analyzer\Tapper.Analyzer.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\..\src\Tapper.Attributes\Tapper.Attributes.csproj" />
+        <ProjectReference Include="..\Tapper.Test.SourceTypes.References\Tapper.Test.SourceTypes.References.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/TypeScriptTest/src/fetch.json.test.ts
+++ b/tests/TypeScriptTest/src/fetch.json.test.ts
@@ -1,55 +1,78 @@
-import { fetchType2, fetchType3, fetchType4, fetchType5, fetchType6 } from './fetch.json'
-import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/json/Tapper.Tests.Server.Models'
+import {
+  fetchType2,
+  fetchType3,
+  fetchType4,
+  fetchType5,
+  fetchType6,
+  fetchType7,
+} from "./fetch.json";
+import {
+  MyEnum,
+  Type2,
+  Type3,
+  Type4,
+  Type5,
+  Type6,
+  Type7,
+} from "./generated/json/Tapper.Tests.Server.Models";
 
-test('fetch1.json', async () => {
-    const res = await fetchType2();
-    const gt: Type2 =
-    {
-        dateTime: new Date('2022-02-06T00:00:00Z'),
-        uri: "http://example.com/2",
-    }
-    expect(res).toEqual(gt);
+test("fetch1.json", async () => {
+  const res = await fetchType2();
+  const gt: Type2 = {
+    dateTime: new Date("2022-02-06T00:00:00Z"),
+    uri: "http://example.com/2",
+  };
+  expect(res).toEqual(gt);
 });
 
-test('fetch2.json', async () => {
-    const res = await fetchType3();
-    const gt: Type3 =
-    {
-        customTypeList: [
-            { id: "3cc614b1-bbce-4677-afb2-9e8dc48c7677", name: "maya", value: 18 },
-            { id: "ee1868fa-7ff2-4699-932a-bc9f331aea11", name: "kuro", value: 11 },
-        ]
-    }
-    expect(res).toEqual(gt);
+test("fetch2.json", async () => {
+  const res = await fetchType3();
+  const gt: Type3 = {
+    customTypeList: [
+      { id: "3cc614b1-bbce-4677-afb2-9e8dc48c7677", name: "maya", value: 18 },
+      { id: "ee1868fa-7ff2-4699-932a-bc9f331aea11", name: "kuro", value: 11 },
+    ],
+  };
+  expect(res).toEqual(gt);
 });
 
-test('fetch4.json', async () => {
-    const res = await fetchType4();
-    const gt: Type4 =
-    {
-        myEnum: MyEnum.Four,
-        value: 7
-    }
-    expect(res).toEqual(gt);
+test("fetch4.json", async () => {
+  const res = await fetchType4();
+  const gt: Type4 = {
+    myEnum: MyEnum.Four,
+    value: 7,
+  };
+  expect(res).toEqual(gt);
 });
 
-
-test('fetch5.json', async () => {
-    const res = await fetchType5();
-    const gt: Type5 =
-    {
-        value: "S"
-    }
-    expect(res).toEqual(gt);
+test("fetch5.json", async () => {
+  const res = await fetchType5();
+  const gt: Type5 = {
+    value: "S",
+  };
+  expect(res).toEqual(gt);
 });
 
-test('fetch6.json', async () => {
-    const res = await fetchType6();
+test("fetch6.json", async () => {
+  const res = await fetchType6();
 
-    const gt: Type6 =
-    {
-        binary: Buffer.from([99, 7, 0]).toString("base64")
-    }
+  const gt: Type6 = {
+    binary: Buffer.from([99, 7, 0]).toString("base64"),
+  };
 
-    expect(res).toEqual(gt);
+  expect(res).toEqual(gt);
+});
+
+test("fetch7.json", async () => {
+  const res = await fetchType7();
+
+  const gt: Type7 = {
+    referencesType: {
+      inheritanceClass0: {
+        value0: 1337,
+      },
+    },
+  };
+
+  expect(res).toEqual(gt);
 });

--- a/tests/TypeScriptTest/src/fetch.json.ts
+++ b/tests/TypeScriptTest/src/fetch.json.ts
@@ -1,86 +1,113 @@
-import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/json/Tapper.Tests.Server.Models';
-import { randomUUID } from 'crypto';
-import fetch from 'node-fetch';
+import {
+  MyEnum,
+  Type2,
+  Type3,
+  Type4,
+  Type5,
+  Type6,
+  Type7,
+} from "./generated/json/Tapper.Tests.Server.Models";
+import { randomUUID } from "crypto";
+import fetch from "node-fetch";
 
 export const fetchType2 = async () => {
-    const obj: Type2 = {
-        dateTime: new Date("2021-06-04"),
-        uri: "http://example.com/1",
-    }
+  const obj: Type2 = {
+    dateTime: new Date("2021-06-04"),
+    uri: "http://example.com/1",
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test1", {
-        method: "POST",
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(obj)
-    });
+  const response = await fetch("http://localhost:5100/tapper/test1", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(obj),
+  });
 
-    const data = await response.json() as Type2;
+  const data = (await response.json()) as Type2;
 
-    data.dateTime = typeof data.dateTime === 'string' ? new Date(data.dateTime) : data.dateTime;
+  data.dateTime =
+    typeof data.dateTime === "string" ? new Date(data.dateTime) : data.dateTime;
 
-    return data;
-}
-
+  return data;
+};
 
 export const fetchType3 = async () => {
-    const obj: Type3 = {
-        customTypeList: [
-            { id: randomUUID(), name: "nana", value: 15 },
-            { id: randomUUID(), name: "junna", value: 25 }
-        ]
-    }
+  const obj: Type3 = {
+    customTypeList: [
+      { id: randomUUID(), name: "nana", value: 15 },
+      { id: randomUUID(), name: "junna", value: 25 },
+    ],
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test2", {
-        method: "POST",
-        body: JSON.stringify(obj),
-        headers: { 'Content-Type': 'application/json' },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test2", {
+    method: "POST",
+    body: JSON.stringify(obj),
+    headers: { "Content-Type": "application/json" },
+  });
 
-    return await response.json() as Type3;
-}
-
+  return (await response.json()) as Type3;
+};
 
 export const fetchType4 = async () => {
-    const obj: Type4 = {
-        myEnum: MyEnum.One,
-        value: 99
-    };
+  const obj: Type4 = {
+    myEnum: MyEnum.One,
+    value: 99,
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test4", {
-        method: "POST",
-        body: JSON.stringify(obj),
-        headers: { 'Content-Type': 'application/json' },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test4", {
+    method: "POST",
+    body: JSON.stringify(obj),
+    headers: { "Content-Type": "application/json" },
+  });
 
-    return await response.json() as Type3;
-}
+  return (await response.json()) as Type3;
+};
 
 export const fetchType5 = async () => {
-    const obj: Type5 = {
-        value: "R"
-    };
+  const obj: Type5 = {
+    value: "R",
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test5", {
-        method: "POST",
-        body: JSON.stringify(obj),
-        headers: { 'Content-Type': 'application/json' },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test5", {
+    method: "POST",
+    body: JSON.stringify(obj),
+    headers: { "Content-Type": "application/json" },
+  });
 
-    return await response.json() as Type5;
-}
+  return (await response.json()) as Type5;
+};
 
 export const fetchType6 = async () => {
-    const obj: Type6 = {
-        binary: Buffer.from([0, 7, 99]).toString("base64")
-    }
+  const obj: Type6 = {
+    binary: Buffer.from([0, 7, 99]).toString("base64"),
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test6", {
-        method: "POST",
-        body: JSON.stringify(obj),
-        headers: { 'Content-Type': 'application/json' },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test6", {
+    method: "POST",
+    body: JSON.stringify(obj),
+    headers: { "Content-Type": "application/json" },
+  });
 
-    const ret = await response.json() as Type6;
+  const ret = (await response.json()) as Type6;
 
-    return ret;
-}
+  return ret;
+};
+
+export const fetchType7 = async () => {
+  const obj: Type7 = {
+    referencesType: {
+      inheritanceClass0: {
+        value0: 1337,
+      },
+    },
+  };
+
+  const response = await fetch("http://localhost:5100/tapper/test7", {
+    method: "POST",
+    body: JSON.stringify(obj),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  const ret = (await response.json()) as Type7;
+
+  return ret;
+};

--- a/tests/TypeScriptTest/src/fetch.msgpack.test.ts
+++ b/tests/TypeScriptTest/src/fetch.msgpack.test.ts
@@ -1,58 +1,82 @@
-import { fetchType2, fetchType3, fetchType4, fetchType5, fetchType6 } from './fetch.msgpack'
-import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/msgpack/Tapper.Tests.Server.Models'
+import {
+  fetchType2,
+  fetchType3,
+  fetchType4,
+  fetchType5,
+  fetchType6,
+  fetchType7,
+} from "./fetch.msgpack";
+import {
+  MyEnum,
+  Type2,
+  Type3,
+  Type4,
+  Type5,
+  Type6,
+  Type7,
+} from "./generated/msgpack/Tapper.Tests.Server.Models";
 
-test('fetch1.msgpack', async () => {
-    const res = await fetchType2();
-    const gt: Type2 =
-    {
-        DateTime: new Date('2022-02-06T00:00:00Z'),
-        Uri: "http://example.com/2",
-    }
-    expect(res).toEqual(gt);
+test("fetch1.msgpack", async () => {
+  const res = await fetchType2();
+  const gt: Type2 = {
+    DateTime: new Date("2022-02-06T00:00:00Z"),
+    Uri: "http://example.com/2",
+  };
+  expect(res).toEqual(gt);
 });
 
-test('fetch2.msgpack', async () => {
-    const res = await fetchType3();
-    const gt: Type3 =
-    {
-        CustomTypeList: [
-            { Id: "3cc614b1-bbce-4677-afb2-9e8dc48c7677", Name: "maya", Value: 18 },
-            { Id: "ee1868fa-7ff2-4699-932a-bc9f331aea11", Name: "kuro", Value: 11 },
-        ]
-    }
-    expect(res).toEqual(gt);
+test("fetch2.msgpack", async () => {
+  const res = await fetchType3();
+  const gt: Type3 = {
+    CustomTypeList: [
+      { Id: "3cc614b1-bbce-4677-afb2-9e8dc48c7677", Name: "maya", Value: 18 },
+      { Id: "ee1868fa-7ff2-4699-932a-bc9f331aea11", Name: "kuro", Value: 11 },
+    ],
+  };
+  expect(res).toEqual(gt);
 });
 
-test('fetch4.msgpack', async () => {
-    const res = await fetchType4();
-    const gt: Type4 =
-    {
-        MyEnum: MyEnum.Four,
-        Value: 7
-    }
-    expect(res).toEqual(gt);
+test("fetch4.msgpack", async () => {
+  const res = await fetchType4();
+  const gt: Type4 = {
+    MyEnum: MyEnum.Four,
+    Value: 7,
+  };
+  expect(res).toEqual(gt);
 });
 
-test('fetch5.msgpack', async () => {
-    const res = await fetchType5();
-    const gt: Type5 =
-    {
-        Value: 83
-    }
-    expect(res).toEqual(gt);
+test("fetch5.msgpack", async () => {
+  const res = await fetchType5();
+  const gt: Type5 = {
+    Value: 83,
+  };
+  expect(res).toEqual(gt);
 });
 
-test('fetch6.msgpack', async () => {
-    const res = await fetchType6();
+test("fetch6.msgpack", async () => {
+  const res = await fetchType6();
 
-    if (res.Binary instanceof Uint8Array) {
-        res.Binary = new Uint8Array(res.Binary)
-    }
+  if (res.Binary instanceof Uint8Array) {
+    res.Binary = new Uint8Array(res.Binary);
+  }
 
-    const gt: Type6 =
-    {
-        Binary: new Uint8Array([99, 7, 0])
-    }
+  const gt: Type6 = {
+    Binary: new Uint8Array([99, 7, 0]),
+  };
 
-    expect(res).toEqual(gt);
+  expect(res).toEqual(gt);
+});
+
+test("fetch7.msgpack", async () => {
+  const res = await fetchType7();
+
+  const gt: Type7 = {
+    ReferencesType: {
+      InheritanceClass0: {
+        Value0: 1337,
+      },
+    },
+  };
+
+  expect(res).toEqual(gt);
 });

--- a/tests/TypeScriptTest/src/fetch.msgpack.ts
+++ b/tests/TypeScriptTest/src/fetch.msgpack.ts
@@ -1,110 +1,140 @@
-import { MyEnum, Type2, Type3, Type4, Type5, Type6 } from './generated/msgpack/Tapper.Tests.Server.Models';
-import { randomUUID } from 'crypto';
+import {
+  MyEnum,
+  Type2,
+  Type3,
+  Type4,
+  Type5,
+  Type6,
+  Type7,
+} from "./generated/msgpack/Tapper.Tests.Server.Models";
+import { randomUUID } from "crypto";
 import { encode, decode } from "@msgpack/msgpack";
-import fetch from 'node-fetch';
+import fetch from "node-fetch";
 
 export const fetchType2 = async () => {
-    const obj: Type2 = {
-        DateTime: new Date("2021-06-04"),
-        Uri: "http://example.com/1",
-    }
+  const obj: Type2 = {
+    DateTime: new Date("2021-06-04"),
+    Uri: "http://example.com/1",
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test1", {
-        method: "POST",
-        headers: {
-            'Content-Type': 'application/x-msgpack',
-            'Accept': 'application/x-msgpack'
-        },
-        body: encode(obj)
-    });
+  const response = await fetch("http://localhost:5100/tapper/test1", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-msgpack",
+      Accept: "application/x-msgpack",
+    },
+    body: encode(obj),
+  });
 
-    const buf = await response.buffer()
-    const ret = decode<Type2>(buf);
+  const buf = await response.buffer();
+  const ret = decode<Type2>(buf);
 
-    return ret;
-}
-
+  return ret;
+};
 
 export const fetchType3 = async () => {
-    const obj: Type3 = {
-        CustomTypeList: [
-            { Id: randomUUID(), Name: "nana", Value: 15 },
-            { Id: randomUUID(), Name: "junna", Value: 25 }
-        ]
-    }
+  const obj: Type3 = {
+    CustomTypeList: [
+      { Id: randomUUID(), Name: "nana", Value: 15 },
+      { Id: randomUUID(), Name: "junna", Value: 25 },
+    ],
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test2", {
-        method: "POST",
-        body: encode(obj),
-        headers: {
-            'Content-Type': 'application/x-msgpack',
-            'Accept': 'application/x-msgpack'
-        },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test2", {
+    method: "POST",
+    body: encode(obj),
+    headers: {
+      "Content-Type": "application/x-msgpack",
+      Accept: "application/x-msgpack",
+    },
+  });
 
-    const buf = await response.buffer()
-    const ret = decode<Type3>(buf);
+  const buf = await response.buffer();
+  const ret = decode<Type3>(buf);
 
-    return ret;
-}
+  return ret;
+};
 
 export const fetchType4 = async () => {
-    const obj: Type4 = {
-        MyEnum: MyEnum.One,
-        Value: 99
-    }
+  const obj: Type4 = {
+    MyEnum: MyEnum.One,
+    Value: 99,
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test4", {
-        method: "POST",
-        body: encode(obj),
-        headers: {
-            'Content-Type': 'application/x-msgpack',
-            'Accept': 'application/x-msgpack'
-        },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test4", {
+    method: "POST",
+    body: encode(obj),
+    headers: {
+      "Content-Type": "application/x-msgpack",
+      Accept: "application/x-msgpack",
+    },
+  });
 
-    const buf = await response.buffer()
-    const ret = decode<Type4>(buf);
+  const buf = await response.buffer();
+  const ret = decode<Type4>(buf);
 
-    return ret;
-}
+  return ret;
+};
 
 export const fetchType5 = async () => {
-    const obj: Type5 = {
-        Value: 82
-    }
+  const obj: Type5 = {
+    Value: 82,
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test5", {
-        method: "POST",
-        body: encode(obj),
-        headers: {
-            'Content-Type': 'application/x-msgpack',
-            'Accept': 'application/x-msgpack'
-        },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test5", {
+    method: "POST",
+    body: encode(obj),
+    headers: {
+      "Content-Type": "application/x-msgpack",
+      Accept: "application/x-msgpack",
+    },
+  });
 
-    const buf = await response.buffer()
-    const ret = decode<Type5>(buf);
+  const buf = await response.buffer();
+  const ret = decode<Type5>(buf);
 
-    return ret;
-}
+  return ret;
+};
 
 export const fetchType6 = async () => {
-    const obj: Type6 = {
-        Binary: new Uint8Array([0, 7, 99])
-    }
+  const obj: Type6 = {
+    Binary: new Uint8Array([0, 7, 99]),
+  };
 
-    const response = await fetch("http://localhost:5100/tapper/test6", {
-        method: "POST",
-        body: encode(obj),
-        headers: {
-            'Content-Type': 'application/x-msgpack',
-            'Accept': 'application/x-msgpack'
-        },
-    });
+  const response = await fetch("http://localhost:5100/tapper/test6", {
+    method: "POST",
+    body: encode(obj),
+    headers: {
+      "Content-Type": "application/x-msgpack",
+      Accept: "application/x-msgpack",
+    },
+  });
 
-    const buf = await response.buffer()
-    const ret = decode<Type6>(buf) as Type6;
+  const buf = await response.buffer();
+  const ret = decode<Type6>(buf) as Type6;
 
-    return ret;
-}
+  return ret;
+};
+export const fetchType7 = async () => {
+  const obj: Type7 = {
+    ReferencesType: {
+      InheritanceClass0: {
+        Value0: 1337,
+      },
+    },
+  };
+
+  const response = await fetch("http://localhost:5100/tapper/test7", {
+    method: "POST",
+    body: encode(obj),
+    headers: {
+      "Content-Type": "application/x-msgpack",
+      Accept: "application/x-msgpack",
+    },
+  });
+
+  const buf = await response.buffer();
+  const ret = decode<Type7>(buf) as Type7;
+
+  return ret;
+};


### PR DESCRIPTION
This allows TargetTypes for compilation to include types referenced recursively by types in the .csproj file being targeted.

It will check fields and properties, as well as the base type of each type in order to find all transpilation targets.

As always, feel free to comment and suggest changes to the flow.

I did not include the `TranspilationSourceAttribute` check on the referenced types, as this could not be guareenteed (though it might be relevant?).

Changes to the TypedSignalR.Client.TypeScript project, might be needed aswell.