### PR TITLE
use GetTypesByMetadataName

### DIFF
--- a/src/Tapper/RoslynExtensions.TypeCollector.cs
+++ b/src/Tapper/RoslynExtensions.TypeCollector.cs
@@ -60,7 +60,7 @@ public static partial class RoslynExtensions
             return TargetTypes;
         }
 
-        var annotationSymbol = compilation.GetTypeByMetadataName("Tapper.TranspilationSourceAttribute");
+        var annotationSymbols = compilation.GetTypesByMetadataName("Tapper.TranspilationSourceAttribute");
 
         var namedTypes = includeReferencedAssemblies ? compilation.GetGlobalNamedTypeSymbols() : compilation.GetNamedTypeSymbols();
 
@@ -74,7 +74,18 @@ public static partial class RoslynExtensions
                     return false;
                 }
 
-                return attributes.Any(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, annotationSymbol));
+                foreach (var attribute in attributes)
+                {
+                    foreach (var annotationSymbol in annotationSymbols)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, annotationSymbol))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
             })
             .ToArray();
 

--- a/src/Tapper/SpecialSymbols.cs
+++ b/src/Tapper/SpecialSymbols.cs
@@ -1,20 +1,21 @@
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
 namespace Tapper;
 
 public class SpecialSymbols
 {
-    public INamedTypeSymbol? JsonPropertyNameAttribute { get; }
-    public INamedTypeSymbol? JsonIgnoreAttribute { get; }
-    public INamedTypeSymbol? MessagePackKeyAttribute { get; }
-    public INamedTypeSymbol? MessagePackIgnoreMemberAttribute { get; }
+    public ImmutableArray<INamedTypeSymbol> JsonPropertyNameAttributes { get; }
+    public ImmutableArray<INamedTypeSymbol> JsonIgnoreAttributes { get; }
+    public ImmutableArray<INamedTypeSymbol> MessagePackKeyAttributes { get; }
+    public ImmutableArray<INamedTypeSymbol> MessagePackIgnoreMemberAttributes { get; }
 
     public SpecialSymbols(Compilation compilation)
     {
-        JsonPropertyNameAttribute = compilation.GetTypeByMetadataName("System.Text.Json.Serialization.JsonPropertyNameAttribute");
-        JsonIgnoreAttribute = compilation.GetTypeByMetadataName("System.Text.Json.Serialization.JsonIgnoreAttribute");
+        JsonPropertyNameAttributes = compilation.GetTypesByMetadataName("System.Text.Json.Serialization.JsonPropertyNameAttribute");
+        JsonIgnoreAttributes = compilation.GetTypesByMetadataName("System.Text.Json.Serialization.JsonIgnoreAttribute");
 
-        MessagePackKeyAttribute = compilation.GetTypeByMetadataName("MessagePack.KeyAttribute");
-        MessagePackIgnoreMemberAttribute = compilation.GetTypeByMetadataName("MessagePack.IgnoreMemberAttribute");
+        MessagePackKeyAttributes = compilation.GetTypesByMetadataName("MessagePack.KeyAttribute");
+        MessagePackIgnoreMemberAttributes = compilation.GetTypesByMetadataName("MessagePack.IgnoreMemberAttribute");
     }
 }

--- a/src/Tapper/TypeTranslators/DefaultMessageTypeTranslator.cs
+++ b/src/Tapper/TypeTranslators/DefaultMessageTypeTranslator.cs
@@ -127,12 +127,12 @@ file static class MessageTypeTranslatorHelper
         {
             foreach (var attr in memberSymbol.GetAttributes())
             {
-                if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, options.SpecialSymbols.JsonIgnoreAttribute))
+                if (options.SpecialSymbols.JsonIgnoreAttributes.Any(x => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, x)))
                 {
                     return (false, string.Empty);
                 }
 
-                if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, options.SpecialSymbols.JsonPropertyNameAttribute))
+                if (options.SpecialSymbols.JsonPropertyNameAttributes.Any(x => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, x)))
                 {
                     var name = attr.ConstructorArguments[0].Value!.ToString()!;
                     return (true, name);
@@ -143,12 +143,12 @@ file static class MessageTypeTranslatorHelper
         {
             foreach (var attr in memberSymbol.GetAttributes())
             {
-                if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, options.SpecialSymbols.MessagePackIgnoreMemberAttribute))
+                if (options.SpecialSymbols.MessagePackIgnoreMemberAttributes.Any(x => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, x)))
                 {
                     return (false, string.Empty);
                 }
 
-                if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, options.SpecialSymbols.MessagePackKeyAttribute))
+                if (options.SpecialSymbols.MessagePackKeyAttributes.Any(x => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, x)))
                 {
                     if (attr.ConstructorArguments[0].Type?.SpecialType == SpecialType.System_String)
                     {


### PR DESCRIPTION
Problems existed when project references were complex. Specifically, `Compilation.GetTypeByMetadataName` could return null. Using the `Compilation.GetTypesByMetadataName` method solves this problem.