### PR TITLE
Fix nested type transpilation (global)

### DIFF
--- a/src/Tapper/GlobalNamedTypeCollector.cs
+++ b/src/Tapper/GlobalNamedTypeCollector.cs
@@ -43,6 +43,11 @@ internal sealed class GlobalNamedTypeCollector : SymbolVisitor
     public override void VisitNamedType(INamedTypeSymbol symbol)
     {
         _namedTypeSymbols.Add(symbol);
+
+        foreach (var member in symbol.GetTypeMembers())
+        {
+            member.Accept(this);
+        }
     }
 
     public INamedTypeSymbol[] ToArray() => _namedTypeSymbols.ToArray();

--- a/tests/Tapper.Tests.AsmReference.SourceTypes2/Class1.cs
+++ b/tests/Tapper.Tests.AsmReference.SourceTypes2/Class1.cs
@@ -8,3 +8,11 @@ public class Class2
     public string? Name2 { get; init; }
     public Guid Id { get; set; }
 }
+
+[TranspilationSource]
+public record NestedTypeParentRequest
+    (IReadOnlyList<NestedTypeParentRequest.NestedTypeNestedTypeParentRequestItem> Items)
+{
+    [TranspilationSource]
+    public record NestedTypeNestedTypeParentRequestItem(int Value, string? Message);
+}

--- a/tests/Tapper.Tests.AsmReference/UnitTest1.cs
+++ b/tests/Tapper.Tests.AsmReference/UnitTest1.cs
@@ -100,5 +100,19 @@ export type Class2 = {
     id: string;
 }
 
+/** Transpiled from Tapper.Tests.AsmReference.SourceTypes2.NestedTypeParentRequest */
+export type NestedTypeParentRequest = {
+    /** Transpiled from System.Collections.Generic.IReadOnlyList<Tapper.Tests.AsmReference.SourceTypes2.NestedTypeParentRequest.NestedTypeNestedTypeParentRequestItem> */
+    items: NestedTypeNestedTypeParentRequestItem[];
+}
+
+/** Transpiled from Tapper.Tests.AsmReference.SourceTypes2.NestedTypeParentRequest.NestedTypeNestedTypeParentRequestItem */
+export type NestedTypeNestedTypeParentRequestItem = {
+    /** Transpiled from int */
+    value: number;
+    /** Transpiled from string? */
+    message?: string;
+}
+
 ";
 }


### PR DESCRIPTION
Fix an issue: nested type fails to transpile when the  `-asm true` option is set.