### PR TITLE
allow TranspilationSourceAttribute to target an interface

### DIFF
--- a/src/Tapper.Attributes/TranspilationSourceAttribute.cs
+++ b/src/Tapper.Attributes/TranspilationSourceAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Tapper;
 
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface)]
 public class TranspilationSourceAttribute : Attribute
 {
 }


### PR DESCRIPTION
I'd like to be able to export interfaces as well. I tested it out by declaring my own copy of the attribute and putting it on an interface and it worked just fine, so I don't think any other changes are required.