### PR TITLE
allow configuring the type used for a C# class

### DIFF
--- a/src/Tapper.Attributes/TranspilationSourceAttribute.cs
+++ b/src/Tapper.Attributes/TranspilationSourceAttribute.cs
@@ -5,4 +5,5 @@ namespace Tapper;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum)]
 public class TranspilationSourceAttribute : Attribute
 {
+    public string? TypescriptType { get; set; }
 }

--- a/tests/Tapper.Test.SourceTypes/AttributeAnnotatedClasses.cs
+++ b/tests/Tapper.Test.SourceTypes/AttributeAnnotatedClasses.cs
@@ -39,3 +39,9 @@ public class AttributeAnnotatedClass4
     public int Value { get; }
     public required string Name { get; init; }
 }
+
+[TranspilationSource(TypescriptType = "{color: 'blue'|'red'}")]
+public class AttributeAnnotatedClass5
+{
+    public string Color { get; init; }
+}

--- a/tests/Tapper.Tests/AttributeAnnotatedClassesTest.cs
+++ b/tests/Tapper.Tests/AttributeAnnotatedClassesTest.cs
@@ -183,4 +183,40 @@ export type AttributeAnnotatedClass4 = {
 
         Assert.Equal(gt, code, ignoreLineEndingDifferences: true);
     }
+
+    [Fact]
+    public void TestClassWithCustomTypescriptType()
+    {
+        var compilation = CompilationSingleton.Compilation;
+
+        var options = new TranspilationOptions(
+            compilation,
+            SerializerOption.Json,
+            NamingStyle.None,
+            EnumStyle.Value,
+            NewLineOption.Lf,
+            4,
+            false,
+            true
+        );
+
+        var codeGenerator = new TypeScriptCodeGenerator(compilation, options);
+
+        var type = typeof(AttributeAnnotatedClass5);
+        var typeSymbol = compilation.GetTypeByMetadataName(type.FullName!)!;
+
+        var writer = new CodeWriter();
+
+        codeGenerator.AddType(typeSymbol, ref writer);
+
+        var code = writer.ToString();
+        var gt = @"/** Transpiled from Tapper.Test.SourceTypes.AttributeAnnotatedClass5 */
+export type AttributeAnnotatedClass5 = {color: 'blue'|'red'};
+";
+
+        _output.WriteLine(code);
+        _output.WriteLine(gt);
+
+        Assert.Equal(gt, code, ignoreLineEndingDifferences: true);
+    }
 }


### PR DESCRIPTION
this allows specifying the type for a class via the `TranspilationSourceAttribute`. Relates to #133 

Example:
```C#
[TranspilationSource(TypescriptType = "{color: 'blue'|'red'}")]
public class AttributeAnnotatedClass5
{
    public string Color { get; init; }
}
```
becomes this: 
```ts
type AttributeAnnotatedClass5 = {color: 'blue'|'red'}
```

This only works at the class level, not the field level. Doing this at the field level would require some more work and I didn't need it.