### PR TITLE
use Cocona instead of ConsoleAppFramework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
         <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     </PropertyGroup>
     <ItemGroup>
+        <PackageVersion Include="Cocona" Version="2.2.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
@@ -19,7 +20,6 @@
         <PackageVersion Include="xunit" Version="2.9.2" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
         <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-        <PackageVersion Include="ConsoleAppFramework" Version="4.2.4" />
         <PackageVersion Include="MessagePack" Version="2.5.187" />
         <PackageVersion Include="MessagePack.AspNetCoreMvcFormatter" Version="2.5.172" />
     </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -488,10 +488,10 @@ export type Type4 = {
 ### Transpile the Types Contained in Referenced Assemblies
 
 By default, only types defined in the project specified by the `--project` option are targeted for transpiling.
-By passing the `-asm true` option, types contained in project/package reference assemblies will also be targeted for transpiling.
+By passing the `--asm true` option, types contained in project/package reference assemblies will also be targeted for transpiling.
 
 ```bash
-tapper --project path/to/Xxx.csproj --output outdir -asm true
+tapper --project path/to/Xxx.csproj --output outdir --asm true
 ```
 
 ## Analyzer

--- a/src/Tapper.Generator/App.cs
+++ b/src/Tapper.Generator/App.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Cocona;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.CodeAnalysis;
@@ -11,34 +12,33 @@ using Microsoft.Extensions.Logging;
 
 namespace Tapper;
 
-public class App : ConsoleAppBase
+public class App : CoconaConsoleAppBase
 {
-    private readonly ILogger<App> _logger;
+    private readonly Microsoft.Extensions.Logging.ILogger _logger;
 
-    public App(ILogger<App> logger)
+    public App(ILoggerFactory loggerFactory)
     {
-        _logger = logger;
+        _logger = loggerFactory.CreateLogger("Tapper");
     }
 
-    [RootCommand]
     public async Task Transpile(
-        [Option("p", "Path to the project file (XXX.csproj)")]
+        [Option('p', Description = "Path to the project file (Xxx.csproj)")]
         string project,
-        [Option("o", "Output directory")]
+        [Option('o', Description = "Output directory")]
         string output,
-        [Option("eol", "lf / crlf / cr")]
+        [Option("eol", Description ="lf / crlf / cr")]
         NewLineOption newLine = NewLineOption.Lf,
-        [Option("i", "Indent size")]
+        [Option('i', Description ="Indent size")]
         int indent = 4,
-        [Option("asm", "The flag whether to extend the transpile target to the referenced assembly.")]
+        [Option("asm", Description ="The flag whether to extend the transpile target to the referenced assembly.")]
         bool assemblies = false,
-        [Option("s", "JSON (default) / MessagePack : The output type will be suitable for the selected serializer.")]
+        [Option('s', Description ="JSON / MessagePack : The output type will be suitable for the selected serializer.")]
         SerializerOption serializer = SerializerOption.Json,
-        [Option("n", "camelCase (default) / PascalCase / none (The name in C# is used as it is.)")]
+        [Option('n', Description ="camelCase / PascalCase / none (The name in C# is used as it is.)")]
         NamingStyle namingStyle = NamingStyle.CamelCase,
-        [Option("en", "value (default) / name / nameCamel / NamePascal / union / unionCamel / UnionPascal")]
+        [Option(Description ="value / name / nameCamel / NamePascal / union / unionCamel / UnionPascal")]
         EnumStyle @enum = EnumStyle.Value,
-        [Option("attr", "The flag whether attributes such as JsonPropertyName should affect transpilation.")]
+        [Option("attr", Description ="The flag whether attributes such as JsonPropertyName should affect transpilation.")]
         bool attribute = true)
     {
         _logger.Log(LogLevel.Information, "Start loading the csproj of {path}.", Path.GetFullPath(project));

--- a/src/Tapper.Generator/Program.cs
+++ b/src/Tapper.Generator/Program.cs
@@ -1,9 +1,18 @@
+using Cocona;
 using Microsoft.Build.Locator;
+using Microsoft.Extensions.Logging;
 using Tapper;
 
 MSBuildLocator.RegisterDefaults();
 
-var app = ConsoleApp.Create(args);
+var builder = CoconaApp.CreateBuilder();
+
+builder.Logging.AddSimpleConsole(options =>
+{
+    options.SingleLine = true;
+});
+
+var app = builder.Build();
 
 app.AddCommands<App>();
 

--- a/src/Tapper.Generator/Tapper.Generator.csproj
+++ b/src/Tapper.Generator/Tapper.Generator.csproj
@@ -23,9 +23,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Cocona" />
         <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
         <PackageReference Include="Microsoft.Build.Locator" />
-        <PackageReference Include="ConsoleAppFramework" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     </ItemGroup>

--- a/tests/Tapper.Tests.AsmReference/Tapper.Tests.AsmReference.csproj
+++ b/tests/Tapper.Tests.AsmReference/Tapper.Tests.AsmReference.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ConsoleAppFramework" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />

--- a/tests/Tapper.Tests.AsmReference/UnitTest1.cs
+++ b/tests/Tapper.Tests.AsmReference/UnitTest1.cs
@@ -52,11 +52,11 @@ public class UnitTest1
 
     private static async Task ExecCommand(string generatorProject, string projectFullPath, string outputFullPath, ITestOutputHelper outputHelper)
     {
-        outputHelper.WriteLine($"run --project {generatorProject} --framework net8.0 -- --project {projectFullPath} --output {outputFullPath} -asm true");
+        outputHelper.WriteLine($"run --project {generatorProject} --framework net8.0 -- --project {projectFullPath} --output {outputFullPath} --asm true");
         var startInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"run --project {generatorProject} --framework net8.0 -- --project {projectFullPath} --output {outputFullPath} -asm true"
+            Arguments = $"run --project {generatorProject} --framework net8.0 -- --project {projectFullPath} --output {outputFullPath} --asm true"
         };
 
         var process = new Process { StartInfo = startInfo };


### PR DESCRIPTION
ConsoleAppFramework v4 is outdated. I needed to migrate to v5, but instead of migrating to v5 I decided to use Cocona.